### PR TITLE
Remove yarn global install from workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,8 +24,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Install yarn globaly
-      run: npm install -g yarn
     - name: yarn install, lint, test
       run: |
         yarn install


### PR DESCRIPTION
This PR removes the yarn global installation step from the node workflow.

~This is a test PR to see if yarn is already available globally on GitHub Action's workflow.~
It works! Yarn is already available. No need to install yarn globally.